### PR TITLE
feature/disable-tf-complate

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -74,12 +74,6 @@ case "${OSTYPE}" in
         ;;
 esac
 
-# Terraform
-if [ -f "$(which terraform)" ];then
-    autoload -U +X bashcompinit && bashcompinit
-    complete -o nospace -C $(which terraform) terraform
-fi
-
 # read .zshrc_local
 if [ -f ~/.zshrc_local ]; then
     . ~/.zshrc_local


### PR DESCRIPTION
* ファイル名の補完が効かなくなるのでTerraformの補完設定を削除