### PR TITLE
feature/wsl-ubuntu-24.04lts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ dotfile達
         * ruby
         * python
         * node.js
+            * npm
+                * tree-sitter-cli
         * go
         * terraform
         * gemini-cli(予定)

--- a/default-npm-packages
+++ b/default-npm-packages
@@ -1,0 +1,1 @@
+tree-sitter-cli

--- a/loc_list.txt
+++ b/loc_list.txt
@@ -3,3 +3,4 @@ zprofile:.zprofile
 starship.toml:.config/starship.toml
 wezterm:.config/wezterm
 git:.config/git
+default-npm-packages:.default-npm-packages

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -7,7 +7,7 @@ local osVal = helpers.osVal
 
 -- Windowsのデフォルトプログラム設定
 if helpers.is_win() then
-  config.default_prog = { 'wsl', '-d', 'Ubuntu-20.04', '--cd', '~' }
+  config.default_prog = { 'wsl', '-d', 'Ubuntu-24.04', '--cd', '~' }
 end
 
 config.color_scheme = 'tokyonight_night'


### PR DESCRIPTION
* weztermのWindowsのデフォルトプログラムをUbuntu 24.04に変更
* nvim-treesitterのmainブランチ移行に必要になったので `tree-sitter-cli` の自動インストール設定を追加
    * 参考) https://github.com/hotaru51/nvim-config/pull/99