### PR TITLE
feature/mod-wezterm-term-and-launch-menu

### DIFF
--- a/wezterm/keymap.lua
+++ b/wezterm/keymap.lua
@@ -92,4 +92,19 @@ if helpers.is_mac() then
   end
 end
 
+-- Windowsの場合、Launcher Menu表示のキーバインドを追加
+if helpers.is_win() then
+  local win_keys = {
+    {
+      key = 'l',
+      mods = 'ALT',
+      action = act.ShowLauncher
+    }
+  }
+
+  for _, key in ipairs(win_keys) do
+    table.insert(keys, key)
+  end
+end
+
 return keys

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -5,9 +5,20 @@ local tabline = wezterm.plugin.require("https://github.com/michaelbrusegard/tabl
 local config = wezterm.config_builder()
 local osVal = helpers.osVal
 
--- Windowsのデフォルトプログラム設定
+-- WindowsのデフォルトプログラムとLaunch Menuの項目設定
 if helpers.is_win() then
   config.default_prog = { 'wsl', '-d', 'Ubuntu-24.04', '--cd', '~' }
+
+  config.launch_menu = {
+    {
+      label = 'PowerShell',
+      args = { 'powershell.exe' }
+    },
+    {
+      label = 'Command Prompt',
+      args = { 'cmd.exe' }
+    },
+  }
 end
 
 config.color_scheme = 'tokyonight_night'

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -21,6 +21,17 @@ if helpers.is_win() then
   }
 end
 
+-- NeoVim 0.12.xでvsplitして右側のウィンドウをスクロールすると左側の表示が崩れる事象の回避
+-- https://github.com/neovim/neovim/issues/35133
+-- 今のところmacOSのみ発生
+-- WezTerm nightlyでは修正されているようなので暫定対応
+if helpers.is_mac() then
+  local sts, _, _ = wezterm.run_child_process({ 'infocmp', 'wezterm' })
+  if sts then
+    config.term = 'wezterm'
+  end
+end
+
 config.color_scheme = 'tokyonight_night'
 -- 現状initial_colsとinitial_rowsは外部ディスプレイでの起動時には正しく反映されない
 -- https://github.com/wez/wezterm/issues/2958


### PR DESCRIPTION
* Windows向けにWezTermのLaunch menuと表示用のキーバインド設定
* NeoVim 0.12.xでvsplit時にscrollしたときに画面が崩れるのでその対策